### PR TITLE
Home row mods

### DIFF
--- a/config/base.keymap
+++ b/config/base.keymap
@@ -44,9 +44,9 @@ ZMK_HOLD_TAP(hmr,
 )
 
 /**
-Home row mods will be CAGS, Control Alt Gui Shift on the left hand side
-                      SGAC, inverted on the left
-Shift in center, then GUI, Alt under the ring finger, and Control under the pinky
+Home row mods will be CCAG, Shift Control Alt Gui on the left hand side
+                      GACS, inverted on the right
+GUI in center, then Alt, Control under the ring finger, and Shift under the pinky
  */
 
 / {

--- a/config/base.keymap
+++ b/config/base.keymap
@@ -7,9 +7,9 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/keys.h>
-/* use helper macros to define left and right hand keys */
-#include "zmk-helpers/key-labels/36.h"                                      // key-position labels
 
+// For Home row mods
+#include "zmk-helpers/key-labels/36.h"                                     // key-position labels
 #define KEYS_L LT0 LT1 LT2 LT3 LT4 LM0 LM1 LM2 LM3 LM4 LB0 LB1 LB2 LB3 LB4  // left-hand keys
 #define KEYS_R RT0 RT1 RT2 RT3 RT4 RM0 RM1 RM2 RM3 RM4 RB0 RB1 RB2 RB3 RB4  // right-hand keys
 #define THUMBS LH2 LH1 LH0 RH0 RH1 RH2                                      // thumb keys
@@ -20,25 +20,25 @@
 #define FUN_L 3
 
 /* left-hand HRMs, e.g. `&hml LSHIFT F` */
-/ ZMK_HOLD_TAP(hml,
-    flavor = "balanced";
-    tapping-term-ms = <280>;
-    quick-tap-ms = <175>;                // repeat on tap-into-hold
-    require-prior-idle-ms = <150>;
-    bindings = <&kp>, <&kp>;
-    hold-trigger-key-positions = <KEYS_R THUMBS>;
-    hold-trigger-on-release;             // delay positional check until key-release
+ZMK_HOLD_TAP(hml, \
+    flavor = "balanced"; \
+    tapping-term-ms = <280>; \
+    quick-tap-ms = <175>; \              // repeat on tap-into-hold
+    require-prior-idle-ms = <150>; \
+    bindings = <&kp>, <&kp>; \
+    hold-trigger-key-positions = <KEYS_R THUMBS>; \
+    hold-trigger-on-release; \           // delay positional check until key-release
 )
 
 /* right-hand HRMs, e.g. `&hmr LSHIFT J` */
-ZMK_HOLD_TAP(hmr,
-    flavor = "balanced";
-    tapping-term-ms = <280>;
-    quick-tap-ms = <175>;                // repeat on tap-into-hold
-    require-prior-idle-ms = <150>;
-    bindings = <&kp>, <&kp>;
-    hold-trigger-key-positions = <KEYS_L THUMBS>;
-    hold-trigger-on-release;             // delay positional check until key-release
+ZMK_HOLD_TAP(hmr, \
+    flavor = "balanced"; \
+    tapping-term-ms = <280>; \
+    quick-tap-ms = <175>; \              // repeat on tap-into-hold
+    require-prior-idle-ms = <150>; \
+    bindings = <&kp>, <&kp>; \
+    hold-trigger-key-positions = <KEYS_L THUMBS>; \
+    hold-trigger-on-release; \           // delay positional check until key-release
 )
 
 /**

--- a/config/base.keymap
+++ b/config/base.keymap
@@ -110,7 +110,7 @@ ZMK_MOD_MORPH(smart_shft,
                    &kp Q        &kp W         &kp E         &kp R              &kp T              &kp Y               &kp U            &kp I                 &kp O         &kp P
                    &hml LSHFT A &hml LCTRL S  &hml LALT D   &hml LGUI F        &kp G              &kp H               &hmr RGUI J      &hmr RALT K           &hmr RCTL L   &hmr RSHFT SEMI
                    &kp Z        &kp X         &kp C         &kp V              &kp B              &kp N               &kp M            &kp COMMA             &kp DOT       &kp SLASH
-				 /*&            &*/           &kp LGUI      &&smart_shft       &lt SYM_L ESC      &lt NAV_L ENTER     &kp SPACE        &mt RGUI TAB /* &             &*/
+				 /*&            &*/           &kp LGUI      &smart_shft       &lt SYM_L ESC      &lt NAV_L ENTER     &kp SPACE        &mt RGUI TAB /* &             &*/
 			>;
 		};
 

--- a/config/base.keymap
+++ b/config/base.keymap
@@ -20,7 +20,7 @@
 #define FUN_L 3
 
 /* left-hand HRMs, e.g. `&hml LSHIFT F` */
-\ ZMK_HOLD_TAP(hml,
+/ ZMK_HOLD_TAP(hml,
     flavor = "balanced";
     tapping-term-ms = <280>;
     quick-tap-ms = <175>;                // repeat on tap-into-hold
@@ -31,7 +31,7 @@
 )
 
 /* right-hand HRMs, e.g. `&hmr LSHIFT J` */
-\ ZMK_HOLD_TAP(hmr,
+ZMK_HOLD_TAP(hmr,
     flavor = "balanced";
     tapping-term-ms = <280>;
     quick-tap-ms = <175>;                // repeat on tap-into-hold

--- a/config/base.keymap
+++ b/config/base.keymap
@@ -100,7 +100,7 @@ Shift in center, then GUI, Alt under the ring finger, and Control under the pink
 		qwerty_layer {
 			bindings = <
                    &kp Q        &kp W         &kp E         &kp R              &kp T              &kp Y               &kp U            &kp I                 &kp O         &kp P
-                   &hml LCTRL A &hml LALT S   &hml LGUI D   &hml LSHFT F       &kp G              &kp H               &hmr RSHFT J     &hmr RGUI K           &hmr RALT L   &hmr RCTL SEMI
+                   &hml LSHFT A &hml LCTRL S  &hml LALT D   &hml LGUI F        &kp G              &kp H               &hmr RGUI J      &hmr RALT K           &hmr RCTL L   &hmr RSHFT SEMI
                    &kp Z        &kp X         &kp C         &kp V              &kp B              &kp N               &kp M            &kp COMMA             &kp DOT       &kp SLASH
 				 /*&            &*/           &kp LGUI      &kp LSHIFT         &lt SYM_L ESC      &lt NAV_L ENTER     &kp SPACE        &mt RGUI TAB /* &             &*/
 			>;
@@ -111,7 +111,7 @@ Shift in center, then GUI, Alt under the ring finger, and Control under the pink
 			bindings = <
                    &kp N1       &kp N2        &kp N3        &kp N4             &kp N5             &kp N6              &kp N7           &kp N8                &kp N9        &kp N0
                    &trans       &kp C_PREV    &kp C_PP      &kp C_NEXT         &kp C_VOL_UP       &kp LEFT            &kp DOWN         &kp UP                &kp RIGHT     &trans
-                   &sk LSHFT    &sk LCTRL     &sk LALT      &sk LGUI           &kp C_VOL_DN       &kp HOME            &kp PG_DN        &kp PG_UP             &kp END       &trans
+                   &trans       &trans        &trans        &trans             &kp C_VOL_DN       &kp HOME            &kp PG_DN        &kp PG_UP             &kp END       &trans
 				 /*&            &*/           &trans        &trans             &trans             &trans              &trans           &trans    /* &             &*/
 			>;
 		};

--- a/config/base.keymap
+++ b/config/base.keymap
@@ -8,37 +8,39 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/keys.h>
 
-// For Home row mods
-#include "zmk-helpers/key-labels/36.h"                                     // key-position labels
-#define KEYS_L LT0 LT1 LT2 LT3 LT4 LM0 LM1 LM2 LM3 LM4 LB0 LB1 LB2 LB3 LB4  // left-hand keys
-#define KEYS_R RT0 RT1 RT2 RT3 RT4 RM0 RM1 RM2 RM3 RM4 RB0 RB1 RB2 RB3 RB4  // right-hand keys
-#define THUMBS LH2 LH1 LH0 RH0 RH1 RH2                                      // thumb keys
-
+// Layer names
 #define QWERTY_L 0
 #define NAV_L 1
 #define SYM_L 2
 #define FUN_L 3
 
+// For Home row mods on a 36 key board
+#include "zmk-helpers/helper.h"
+#include "zmk-helpers/key-labels/36.h"                                     // key-position labels
+#define KEYS_L LT0 LT1 LT2 LT3 LT4 LM0 LM1 LM2 LM3 LM4 LB0 LB1 LB2 LB3 LB4  // left-hand keys
+#define KEYS_R RT0 RT1 RT2 RT3 RT4 RM0 RM1 RM2 RM3 RM4 RB0 RB1 RB2 RB3 RB4  // right-hand keys
+#define THUMBS LH2 LH1 LH0 RH0 RH1 RH2                                      // thumb keys
+
 /* left-hand HRMs, e.g. `&hml LSHIFT F` */
-ZMK_HOLD_TAP(hml, \
-    flavor = "balanced"; \
-    tapping-term-ms = <280>; \
-    quick-tap-ms = <175>; \              // repeat on tap-into-hold
-    require-prior-idle-ms = <150>; \
-    bindings = <&kp>, <&kp>; \
-    hold-trigger-key-positions = <KEYS_R THUMBS>; \
-    hold-trigger-on-release; \           // delay positional check until key-release
+ZMK_HOLD_TAP(hml,
+    flavor = "balanced";
+    tapping-term-ms = <280>;
+    quick-tap-ms = <175>;                // repeat on tap-into-hold
+    require-prior-idle-ms = <150>;
+    bindings = <&kp>, <&kp>;
+    hold-trigger-key-positions = <KEYS_R THUMBS>;
+    hold-trigger-on-release;             // delay positional check until key-release
 )
 
 /* right-hand HRMs, e.g. `&hmr LSHIFT J` */
-ZMK_HOLD_TAP(hmr, \
-    flavor = "balanced"; \
-    tapping-term-ms = <280>; \
-    quick-tap-ms = <175>; \              // repeat on tap-into-hold
-    require-prior-idle-ms = <150>; \
-    bindings = <&kp>, <&kp>; \
-    hold-trigger-key-positions = <KEYS_L THUMBS>; \
-    hold-trigger-on-release; \           // delay positional check until key-release
+ZMK_HOLD_TAP(hmr,
+    flavor = "balanced";
+    tapping-term-ms = <280>;
+    quick-tap-ms = <175>;                // repeat on tap-into-hold
+    require-prior-idle-ms = <150>;
+    bindings = <&kp>, <&kp>;
+    hold-trigger-key-positions = <KEYS_L THUMBS>;
+    hold-trigger-on-release;             // delay positional check until key-release
 )
 
 /**

--- a/config/base.keymap
+++ b/config/base.keymap
@@ -7,11 +7,45 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/keys.h>
+/* use helper macros to define left and right hand keys */
+#include "zmk-helpers/key-labels/36.h"                                      // key-position labels
+
+#define KEYS_L LT0 LT1 LT2 LT3 LT4 LM0 LM1 LM2 LM3 LM4 LB0 LB1 LB2 LB3 LB4  // left-hand keys
+#define KEYS_R RT0 RT1 RT2 RT3 RT4 RM0 RM1 RM2 RM3 RM4 RB0 RB1 RB2 RB3 RB4  // right-hand keys
+#define THUMBS LH2 LH1 LH0 RH0 RH1 RH2                                      // thumb keys
 
 #define QWERTY_L 0
 #define NAV_L 1
 #define SYM_L 2
 #define FUN_L 3
+
+/* left-hand HRMs, e.g. `&hml LSHIFT F` */
+ZMK_HOLD_TAP(hml,
+    flavor = "balanced";
+    tapping-term-ms = <280>;
+    quick-tap-ms = <175>;                // repeat on tap-into-hold
+    require-prior-idle-ms = <150>;
+    bindings = <&kp>, <&kp>;
+    hold-trigger-key-positions = <KEYS_R THUMBS>;
+    hold-trigger-on-release;             // delay positional check until key-release
+)
+
+/* right-hand HRMs, e.g. `&hmr LSHIFT J` */
+ZMK_HOLD_TAP(hmr,
+    flavor = "balanced";
+    tapping-term-ms = <280>;
+    quick-tap-ms = <175>;                // repeat on tap-into-hold
+    require-prior-idle-ms = <150>;
+    bindings = <&kp>, <&kp>;
+    hold-trigger-key-positions = <KEYS_L THUMBS>;
+    hold-trigger-on-release;             // delay positional check until key-release
+)
+
+/**
+Home row mods will be CAGS, Control Alt Gui Shift on the left hand side
+                      SGAC, inverted on the left
+Shift in center, then GUI, Alt under the ring finger, and Control under the pinky
+ */
 
 / {
     
@@ -28,6 +62,11 @@
     combos {
         compatible = "zmk,combos";
 
+        // Helper for defining combos with simpler syntax
+        // @example
+        // ```
+        // COMBO(lctrl, &kp LCTRL, 21 22, 50)
+        // ```
         #define COMBO(NAME, BINDINGS, KEYPOS, TIMEOUT) \
             combo_##NAME { \
                 timeout-ms = <TIMEOUT>; \
@@ -59,7 +98,7 @@
 		qwerty_layer {
 			bindings = <
                    &kp Q        &kp W         &kp E         &kp R              &kp T              &kp Y               &kp U            &kp I                 &kp O         &kp P
-                   &kp A        &kp S         &kp D         &kp F              &kp G              &kp H               &kp J            &kp K                 &kp L         &kp SEMI
+                   &hml LCTRL A &hml LALT S   &hml LGUI D   &hml LSHFT F       &kp G              &kp H               &hmr RSHFT J     &hmr RGUI K           &hmr RALT L   &hmr RCTL SEMI
                    &kp Z        &kp X         &kp C         &kp V              &kp B              &kp N               &kp M            &kp COMMA             &kp DOT       &kp SLASH
 				 /*&            &*/           &kp LGUI      &kp LSHIFT         &lt SYM_L ESC      &lt NAV_L ENTER     &kp SPACE        &mt RGUI TAB /* &             &*/
 			>;

--- a/config/base.keymap
+++ b/config/base.keymap
@@ -20,7 +20,7 @@
 #define FUN_L 3
 
 /* left-hand HRMs, e.g. `&hml LSHIFT F` */
-ZMK_HOLD_TAP(hml,
+\ ZMK_HOLD_TAP(hml,
     flavor = "balanced";
     tapping-term-ms = <280>;
     quick-tap-ms = <175>;                // repeat on tap-into-hold
@@ -31,7 +31,7 @@ ZMK_HOLD_TAP(hml,
 )
 
 /* right-hand HRMs, e.g. `&hmr LSHIFT J` */
-ZMK_HOLD_TAP(hmr,
+\ ZMK_HOLD_TAP(hmr,
     flavor = "balanced";
     tapping-term-ms = <280>;
     quick-tap-ms = <175>;                // repeat on tap-into-hold

--- a/config/base.keymap
+++ b/config/base.keymap
@@ -93,8 +93,6 @@ ZMK_MOD_MORPH(smart_shft,
           ╰───────╮ 30  31  32 │ │ 33  34  35 ╭───────╯
                   ╰────────────╯ ╰────────────╯        */
 
-        COMBO(caps_word_left, &caps_word, 13 16, 50)
-
         COMBO(lctrl, &kp LCTRL, 21 22, 50)
         COMBO(lalt,  &kp LALT,  22 23, 50)
         COMBO(ralt,  &kp RALT,  26 27, 50)

--- a/config/base.keymap
+++ b/config/base.keymap
@@ -14,6 +14,12 @@
 #define SYM_L 2
 #define FUN_L 3
 
+/**
+Home row mods will be CCAG, Shift Control Alt Gui on the left hand side
+                      GACS, inverted on the right
+GUI in center, then Alt, Control under the ring finger, and Shift under the pinky
+ */
+
 // For Home row mods on a 36 key board
 #include "zmk-helpers/helper.h"
 #include "zmk-helpers/key-labels/36.h"                                     // key-position labels
@@ -43,11 +49,13 @@ ZMK_HOLD_TAP(hmr,
     hold-trigger-on-release;             // delay positional check until key-release
 )
 
-/**
-Home row mods will be CCAG, Shift Control Alt Gui on the left hand side
-                      GACS, inverted on the right
-GUI in center, then Alt, Control under the ring finger, and Shift under the pinky
- */
+ /* Caps-word, num-word and smart-mouse */
+
+// tap: sticky-shift | shift + tap/ double-tap: caps-word | hold: shift
+ZMK_MOD_MORPH(smart_shft,
+    bindings = <&sk LSHFT>, <&caps_word>;
+    mods = <(MOD_LSFT)>;
+)
 
 / {
     
@@ -102,7 +110,7 @@ GUI in center, then Alt, Control under the ring finger, and Shift under the pink
                    &kp Q        &kp W         &kp E         &kp R              &kp T              &kp Y               &kp U            &kp I                 &kp O         &kp P
                    &hml LSHFT A &hml LCTRL S  &hml LALT D   &hml LGUI F        &kp G              &kp H               &hmr RGUI J      &hmr RALT K           &hmr RCTL L   &hmr RSHFT SEMI
                    &kp Z        &kp X         &kp C         &kp V              &kp B              &kp N               &kp M            &kp COMMA             &kp DOT       &kp SLASH
-				 /*&            &*/           &kp LGUI      &kp LSHIFT         &lt SYM_L ESC      &lt NAV_L ENTER     &kp SPACE        &mt RGUI TAB /* &             &*/
+				 /*&            &*/           &kp LGUI      &&smart_shft       &lt SYM_L ESC      &lt NAV_L ENTER     &kp SPACE        &mt RGUI TAB /* &             &*/
 			>;
 		};
 

--- a/config/west.yml
+++ b/config/west.yml
@@ -2,12 +2,15 @@ manifest:
   remotes:
     - name: zmkfirmware
       url-base: https://github.com/zmkfirmware
-    # Additional modules containing boards/shields/custom code can be listed here as well
-    # See https://docs.zephyrproject.org/3.2.0/develop/west/manifest.html#projects
+    - name: urob
+      url-base: https://github.com/urob
   projects:
     - name: zmk
       remote: zmkfirmware
       revision: main
       import: app/west.yml
+    - name: zmk-helpers
+      remote: urob
+      revision: main
   self:
     path: config

--- a/keymap-drawer/base.yaml
+++ b/keymap-drawer/base.yaml
@@ -10,16 +10,16 @@ layers:
   - I
   - O
   - P
-  - '&hml LCTRL A'
-  - '&hml LALT S'
-  - '&hml LGUI D'
-  - '&hml LSHFT F'
+  - '&hml LSHFT A'
+  - '&hml LCTRL S'
+  - '&hml LALT D'
+  - '&hml LGUI F'
   - G
   - H
-  - '&hmr RSHFT J'
-  - '&hmr RGUI K'
-  - '&hmr RALT L'
-  - '&hmr RCTL SEMI'
+  - '&hmr RGUI J'
+  - '&hmr RALT K'
+  - '&hmr RCTL L'
+  - '&hmr RSHFT SEMI'
   - Z
   - X
   - C
@@ -57,10 +57,10 @@ layers:
   - UP
   - RIGHT
   - {t: ▽, type: trans}
-  - {t: LSHFT, h: sticky}
-  - {t: LCTRL, h: sticky}
-  - {t: LALT, h: sticky}
-  - {t: LGUI, h: sticky}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
   - VOL DN
   - HOME
   - PG DN

--- a/keymap-drawer/base.yaml
+++ b/keymap-drawer/base.yaml
@@ -10,16 +10,16 @@ layers:
   - I
   - O
   - P
-  - A
-  - S
-  - D
-  - F
+  - '&hml LCTRL A'
+  - '&hml LALT S'
+  - '&hml LGUI D'
+  - '&hml LSHFT F'
   - G
   - H
-  - J
-  - K
-  - L
-  - ;
+  - '&hmr RSHFT J'
+  - '&hmr RGUI K'
+  - '&hmr RALT L'
+  - '&hmr RCTL SEMI'
   - Z
   - X
   - C

--- a/keymap-drawer/base.yaml
+++ b/keymap-drawer/base.yaml
@@ -31,7 +31,7 @@ layers:
   - .
   - /
   - LGUI
-  - LSHIFT
+  - '&smart_shft'
   - {t: ESC, h: sym}
   - {t: ENTER, h: nav}
   - SPACE

--- a/keymap-drawer/base.yaml
+++ b/keymap-drawer/base.yaml
@@ -148,8 +148,6 @@ layers:
   - {t: ▽, type: trans}
   - {t: ▽, type: trans}
 combos:
-- p: [13, 16]
-  k: '&caps_word'
 - p: [21, 22]
   k: LCTRL
 - p: [22, 23]

--- a/keymap-drawer/rae_dux.svg
+++ b/keymap-drawer/rae_dux.svg
@@ -269,7 +269,7 @@ path.combo {
 </g>
 <g transform="translate(280, 235)" class="key keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">LSHIFT</text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">&amp;smart_shft</tspan></text>
 </g>
 <g transform="translate(336, 258)" class="key keypos-32">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/keymap-drawer/rae_dux.svg
+++ b/keymap-drawer/rae_dux.svg
@@ -162,28 +162,28 @@ path.combo {
 <g transform="translate(28, 140)" class="key keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">&amp;hml</tspan><tspan x="0" dy="1.2em">LCTRL</tspan>
+<tspan x="0" dy="-1.2em">&amp;hml</tspan><tspan x="0" dy="1.2em">LSHFT</tspan>
 <tspan x="0" dy="1.2em">A</tspan>
 </text>
 </g>
 <g transform="translate(84, 98)" class="key keypos-11">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">&amp;hml</tspan><tspan x="0" dy="1.2em">LALT</tspan>
+<tspan x="0" dy="-1.2em">&amp;hml</tspan><tspan x="0" dy="1.2em">LCTRL</tspan>
 <tspan x="0" dy="1.2em">S</tspan>
 </text>
 </g>
 <g transform="translate(140, 84)" class="key keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">&amp;hml</tspan><tspan x="0" dy="1.2em">LGUI</tspan>
+<tspan x="0" dy="-1.2em">&amp;hml</tspan><tspan x="0" dy="1.2em">LALT</tspan>
 <tspan x="0" dy="1.2em">D</tspan>
 </text>
 </g>
 <g transform="translate(196, 105)" class="key keypos-13">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">&amp;hml</tspan><tspan x="0" dy="1.2em">LSHFT</tspan>
+<tspan x="0" dy="-1.2em">&amp;hml</tspan><tspan x="0" dy="1.2em">LGUI</tspan>
 <tspan x="0" dy="1.2em">F</tspan>
 </text>
 </g>
@@ -198,28 +198,28 @@ path.combo {
 <g transform="translate(588, 105)" class="key keypos-16">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">&amp;hmr</tspan><tspan x="0" dy="1.2em">RSHFT</tspan>
+<tspan x="0" dy="-1.2em">&amp;hmr</tspan><tspan x="0" dy="1.2em">RGUI</tspan>
 <tspan x="0" dy="1.2em">J</tspan>
 </text>
 </g>
 <g transform="translate(644, 84)" class="key keypos-17">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">&amp;hmr</tspan><tspan x="0" dy="1.2em">RGUI</tspan>
+<tspan x="0" dy="-1.2em">&amp;hmr</tspan><tspan x="0" dy="1.2em">RALT</tspan>
 <tspan x="0" dy="1.2em">K</tspan>
 </text>
 </g>
 <g transform="translate(700, 98)" class="key keypos-18">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">&amp;hmr</tspan><tspan x="0" dy="1.2em">RALT</tspan>
+<tspan x="0" dy="-1.2em">&amp;hmr</tspan><tspan x="0" dy="1.2em">RCTL</tspan>
 <tspan x="0" dy="1.2em">L</tspan>
 </text>
 </g>
 <g transform="translate(756, 140)" class="key keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">&amp;hmr</tspan><tspan x="0" dy="1.2em">RCTL</tspan>
+<tspan x="0" dy="-1.2em">&amp;hmr</tspan><tspan x="0" dy="1.2em">RSHFT</tspan>
 <tspan x="0" dy="1.2em">SEMI</tspan>
 </text>
 </g>
@@ -401,25 +401,21 @@ path.combo {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(28, 196)" class="key keypos-20">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">LSHFT</text>
-<text x="0" y="24" class="key hold">sticky</text>
+<g transform="translate(28, 196)" class="key trans keypos-20">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(84, 154)" class="key keypos-21">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">LCTRL</text>
-<text x="0" y="24" class="key hold">sticky</text>
+<g transform="translate(84, 154)" class="key trans keypos-21">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(140, 140)" class="key keypos-22">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">LALT</text>
-<text x="0" y="24" class="key hold">sticky</text>
+<g transform="translate(140, 140)" class="key trans keypos-22">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(196, 161)" class="key keypos-23">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">LGUI</text>
-<text x="0" y="24" class="key hold">sticky</text>
+<g transform="translate(196, 161)" class="key trans keypos-23">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
 </g>
 <g transform="translate(252, 168)" class="key keypos-24">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/keymap-drawer/rae_dux.svg
+++ b/keymap-drawer/rae_dux.svg
@@ -161,19 +161,31 @@ path.combo {
 </g>
 <g transform="translate(28, 140)" class="key keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">A</text>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-1.2em">&amp;hml</tspan><tspan x="0" dy="1.2em">LCTRL</tspan>
+<tspan x="0" dy="1.2em">A</tspan>
+</text>
 </g>
 <g transform="translate(84, 98)" class="key keypos-11">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">S</text>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-1.2em">&amp;hml</tspan><tspan x="0" dy="1.2em">LALT</tspan>
+<tspan x="0" dy="1.2em">S</tspan>
+</text>
 </g>
 <g transform="translate(140, 84)" class="key keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">D</text>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-1.2em">&amp;hml</tspan><tspan x="0" dy="1.2em">LGUI</tspan>
+<tspan x="0" dy="1.2em">D</tspan>
+</text>
 </g>
 <g transform="translate(196, 105)" class="key keypos-13">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">F</text>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-1.2em">&amp;hml</tspan><tspan x="0" dy="1.2em">LSHFT</tspan>
+<tspan x="0" dy="1.2em">F</tspan>
+</text>
 </g>
 <g transform="translate(252, 112)" class="key keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -185,19 +197,31 @@ path.combo {
 </g>
 <g transform="translate(588, 105)" class="key keypos-16">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">J</text>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-1.2em">&amp;hmr</tspan><tspan x="0" dy="1.2em">RSHFT</tspan>
+<tspan x="0" dy="1.2em">J</tspan>
+</text>
 </g>
 <g transform="translate(644, 84)" class="key keypos-17">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">K</text>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-1.2em">&amp;hmr</tspan><tspan x="0" dy="1.2em">RGUI</tspan>
+<tspan x="0" dy="1.2em">K</tspan>
+</text>
 </g>
 <g transform="translate(700, 98)" class="key keypos-18">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">L</text>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-1.2em">&amp;hmr</tspan><tspan x="0" dy="1.2em">RALT</tspan>
+<tspan x="0" dy="1.2em">L</tspan>
+</text>
 </g>
 <g transform="translate(756, 140)" class="key keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">;</text>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-1.2em">&amp;hmr</tspan><tspan x="0" dy="1.2em">RCTL</tspan>
+<tspan x="0" dy="1.2em">SEMI</tspan>
+</text>
 </g>
 <g transform="translate(28, 196)" class="key keypos-20">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/keymap-drawer/rae_dux.svg
+++ b/keymap-drawer/rae_dux.svg
@@ -293,24 +293,18 @@ path.combo {
 <text x="0" y="24" class="key hold">RGUI</text>
 </g>
 <g class="combo combopos-0">
-<path d="M392,105 l-177,0" class="combo"/>
-<path d="M392,105 l177,0" class="combo"/>
-<rect rx="6" ry="6" x="378" y="92" width="28" height="26" class="combo"/>
-<text x="392" y="105" class="combo tap"><tspan style="font-size: 70%">&amp;caps_word</tspan></text>
-</g>
-<g class="combo combopos-1">
 <rect rx="6" ry="6" x="98" y="134" width="28" height="26" class="combo"/>
 <text x="112" y="147" class="combo tap">LCTRL</text>
 </g>
-<g class="combo combopos-2">
+<g class="combo combopos-1">
 <rect rx="6" ry="6" x="154" y="138" width="28" height="26" class="combo"/>
 <text x="168" y="150" class="combo tap">LALT</text>
 </g>
-<g class="combo combopos-3">
+<g class="combo combopos-2">
 <rect rx="6" ry="6" x="602" y="138" width="28" height="26" class="combo"/>
 <text x="616" y="150" class="combo tap">RALT</text>
 </g>
-<g class="combo combopos-4">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="658" y="134" width="28" height="26" class="combo"/>
 <text x="672" y="147" class="combo tap">LCTRL</text>
 </g>
@@ -471,24 +465,18 @@ path.combo {
 <text x="0" y="0" class="key trans tap">▽</text>
 </g>
 <g class="combo combopos-0">
-<path d="M392,105 l-177,0" class="combo"/>
-<path d="M392,105 l177,0" class="combo"/>
-<rect rx="6" ry="6" x="378" y="92" width="28" height="26" class="combo"/>
-<text x="392" y="105" class="combo tap"><tspan style="font-size: 70%">&amp;caps_word</tspan></text>
-</g>
-<g class="combo combopos-1">
 <rect rx="6" ry="6" x="98" y="134" width="28" height="26" class="combo"/>
 <text x="112" y="147" class="combo tap">LCTRL</text>
 </g>
-<g class="combo combopos-2">
+<g class="combo combopos-1">
 <rect rx="6" ry="6" x="154" y="138" width="28" height="26" class="combo"/>
 <text x="168" y="150" class="combo tap">LALT</text>
 </g>
-<g class="combo combopos-3">
+<g class="combo combopos-2">
 <rect rx="6" ry="6" x="602" y="138" width="28" height="26" class="combo"/>
 <text x="616" y="150" class="combo tap">RALT</text>
 </g>
-<g class="combo combopos-4">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="658" y="134" width="28" height="26" class="combo"/>
 <text x="672" y="147" class="combo tap">LCTRL</text>
 </g>
@@ -641,24 +629,18 @@ path.combo {
 <text x="0" y="0" class="key trans tap">▽</text>
 </g>
 <g class="combo combopos-0">
-<path d="M392,105 l-177,0" class="combo"/>
-<path d="M392,105 l177,0" class="combo"/>
-<rect rx="6" ry="6" x="378" y="92" width="28" height="26" class="combo"/>
-<text x="392" y="105" class="combo tap"><tspan style="font-size: 70%">&amp;caps_word</tspan></text>
-</g>
-<g class="combo combopos-1">
 <rect rx="6" ry="6" x="98" y="134" width="28" height="26" class="combo"/>
 <text x="112" y="147" class="combo tap">LCTRL</text>
 </g>
-<g class="combo combopos-2">
+<g class="combo combopos-1">
 <rect rx="6" ry="6" x="154" y="138" width="28" height="26" class="combo"/>
 <text x="168" y="150" class="combo tap">LALT</text>
 </g>
-<g class="combo combopos-3">
+<g class="combo combopos-2">
 <rect rx="6" ry="6" x="602" y="138" width="28" height="26" class="combo"/>
 <text x="616" y="150" class="combo tap">RALT</text>
 </g>
-<g class="combo combopos-4">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="658" y="134" width="28" height="26" class="combo"/>
 <text x="672" y="147" class="combo tap">LCTRL</text>
 </g>
@@ -823,24 +805,18 @@ path.combo {
 <text x="0" y="0" class="key trans tap">▽</text>
 </g>
 <g class="combo combopos-0">
-<path d="M392,105 l-177,0" class="combo"/>
-<path d="M392,105 l177,0" class="combo"/>
-<rect rx="6" ry="6" x="378" y="92" width="28" height="26" class="combo"/>
-<text x="392" y="105" class="combo tap"><tspan style="font-size: 70%">&amp;caps_word</tspan></text>
-</g>
-<g class="combo combopos-1">
 <rect rx="6" ry="6" x="98" y="134" width="28" height="26" class="combo"/>
 <text x="112" y="147" class="combo tap">LCTRL</text>
 </g>
-<g class="combo combopos-2">
+<g class="combo combopos-1">
 <rect rx="6" ry="6" x="154" y="138" width="28" height="26" class="combo"/>
 <text x="168" y="150" class="combo tap">LALT</text>
 </g>
-<g class="combo combopos-3">
+<g class="combo combopos-2">
 <rect rx="6" ry="6" x="602" y="138" width="28" height="26" class="combo"/>
 <text x="616" y="150" class="combo tap">RALT</text>
 </g>
-<g class="combo combopos-4">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="658" y="134" width="28" height="26" class="combo"/>
 <text x="672" y="147" class="combo tap">LCTRL</text>
 </g>

--- a/keymap-drawer/rae_dux.yaml
+++ b/keymap-drawer/rae_dux.yaml
@@ -11,16 +11,16 @@ layers:
   - I
   - O
   - P
-  - A
-  - S
-  - D
-  - F
+  - '&hml LCTRL A'
+  - '&hml LALT S'
+  - '&hml LGUI D'
+  - '&hml LSHFT F'
   - G
   - H
-  - J
-  - K
-  - L
-  - ;
+  - '&hmr RSHFT J'
+  - '&hmr RGUI K'
+  - '&hmr RALT L'
+  - '&hmr RCTL SEMI'
   - Z
   - X
   - C

--- a/keymap-drawer/rae_dux.yaml
+++ b/keymap-drawer/rae_dux.yaml
@@ -149,8 +149,6 @@ layers:
   - {t: ▽, type: trans}
   - {t: ▽, type: trans}
 combos:
-- p: [13, 16]
-  k: '&caps_word'
 - p: [21, 22]
   k: LCTRL
 - p: [22, 23]

--- a/keymap-drawer/rae_dux.yaml
+++ b/keymap-drawer/rae_dux.yaml
@@ -32,7 +32,7 @@ layers:
   - .
   - /
   - LGUI
-  - LSHIFT
+  - '&smart_shft'
   - {t: ESC, h: sym}
   - {t: ENTER, h: nav}
   - SPACE

--- a/keymap-drawer/rae_dux.yaml
+++ b/keymap-drawer/rae_dux.yaml
@@ -11,16 +11,16 @@ layers:
   - I
   - O
   - P
-  - '&hml LCTRL A'
-  - '&hml LALT S'
-  - '&hml LGUI D'
-  - '&hml LSHFT F'
+  - '&hml LSHFT A'
+  - '&hml LCTRL S'
+  - '&hml LALT D'
+  - '&hml LGUI F'
   - G
   - H
-  - '&hmr RSHFT J'
-  - '&hmr RGUI K'
-  - '&hmr RALT L'
-  - '&hmr RCTL SEMI'
+  - '&hmr RGUI J'
+  - '&hmr RALT K'
+  - '&hmr RCTL L'
+  - '&hmr RSHFT SEMI'
   - Z
   - X
   - C
@@ -58,10 +58,10 @@ layers:
   - UP
   - RIGHT
   - {t: ▽, type: trans}
-  - {t: LSHFT, h: sticky}
-  - {t: LCTRL, h: sticky}
-  - {t: LALT, h: sticky}
-  - {t: LGUI, h: sticky}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
   - VOL DN
   - HOME
   - PG DN


### PR DESCRIPTION
Using [urob's zmk config](https://github.com/urob/zmk-config/tree/main) as a guide:

- add home row mods (SCAG on the left hand)
- Add smart shift on thumb (tap is one-shot mod, hold is normal, double tap for caps word)
- Remove caps-word from J+K combo
- Remove one-shot mods from left hand bottom row in nav layer